### PR TITLE
Add blog

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.4/css/all.css" integrity="sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm" crossorigin="anonymous">
 <style>
 @import url('https://fonts.googleapis.com/css?family=Roboto');
 

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@ a{
         <div class="section-1">
             <i class="fas fa-code fa-5x white"></i>
             <h2>ATO Pathways has become obsolete</h2>
+            <p>A detailed explanation of why and what to do now can be found at <a href="https://www.redhat.com/en/blog/obsolescence-ato-pathways">the Red Hat Blog</a>.</p>
             <p>If you have questions that aren't answered here, please email <a href="mailto:atopathways@redhat.com">atopathways@redhat.com</a>.</p>
             <p><a href="https://github.com/ComplianceAsCode"><i class="fab fa-github"></i></a></p>
         </div>


### PR DESCRIPTION
Adds a link to [the blog post](https://www.redhat.com/en/blog/obsolescence-ato-pathways) that goes into much more detail about why ATO Pathways was retired.

Also bumped FontAwesome CSS version.